### PR TITLE
Update pipeline to dsl2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-jdk: openjdk8
+jdk: openjdk11
 services:
 - docker
 install:

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Run the script
 
 ## Dependencies 
 
-* Java 8 or later 
+* Java 11 or later 
 * Docker 1.10 or later 

--- a/main.nf
+++ b/main.nf
@@ -34,28 +34,47 @@ params.chunkSize = 100
 db_name = file(params.db).name
 db_dir = file(params.db).parent
 
-/* 
- * Given the query parameter creates a channel emitting the query fasta file(s), 
- * the file is split in chunks containing as many sequences as defined by the parameter 'chunkSize'.
- * Finally assign the result channel to the variable 'fasta_ch' 
- */
-Channel
-    .fromPath(params.query)
-    .splitFasta(by: params.chunkSize, file:true)
-    .set { fasta_ch }
 
-/* 
- * Executes a BLAST job for each chunk emitted by the 'fasta_ch' channel 
- * and creates as output a channel named 'top_hits' emitting the resulting 
- * BLAST matches  
- */
+workflow {
+    /*
+     * Create a channel emitting the given query fasta file(s).
+     * Split the file into chunks containing as many sequences as defined by the parameter 'chunkSize'.
+     * Finally, assign the resulting channel to the variable 'ch_fasta'
+     */
+    Channel
+        .fromPath(params.query)
+        .splitFasta(by: params.chunkSize, file:true)
+        .set { ch_fasta }
+
+    /*
+     * Execute a BLAST job for each chunk emitted by the 'ch_fasta' channel
+     * and emit the resulting BLAST matches.
+     */
+    ch_hits = blast(ch_fasta, db_dir)
+
+    /*
+     * Each time a file emitted by the 'blast' process, an extract job is executed,
+     * producing a file containing the matching sequences.
+     */
+    ch_sequences = extract(ch_hits, db_dir)
+
+    /*
+     * Collect all the sequences files into a single file
+     * and print the resulting file contents when complete.
+     */
+    ch_sequences
+        .collectFile(name: params.out)
+        .view { file -> "matching sequences:\n ${file.text}" }
+}
+
+
 process blast {
     input:
-    path 'query.fa' from fasta_ch
-    path db from db_dir
+    path 'query.fa'
+    path db
 
     output:
-    file 'top_hits' into hits_ch
+    path 'top_hits'
 
     """
     blastp -db $db/$db_name -query query.fa -outfmt 6 > blast_result
@@ -63,27 +82,16 @@ process blast {
     """
 }
 
-/* 
- * Each time a file emitted by the 'top_hits' channel an extract job is executed 
- * producing a file containing the matching sequences 
- */
+
 process extract {
     input:
-    path 'top_hits' from hits_ch
-    path db from db_dir
+    path 'top_hits'
+    path db
 
     output:
-    file 'sequences' into sequences_ch
+    path 'sequences'
 
     """
     blastdbcmd -db $db/$db_name -entry_batch top_hits | head -n 10 > sequences
     """
 }
-
-/* 
- * Collects all the sequences files into a single file 
- * and prints the resulting file content when complete 
- */ 
-sequences_ch
-    .collectFile(name: params.out)
-    .view { file -> "matching sequences:\n ${file.text}" }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 manifest {
-  nextflowVersion = '>= 20.01.0'
+  nextflowVersion = '>= 22.04.0'
 }
 
 process {


### PR DESCRIPTION
Updates pipeline to DSL2. Also updates requirements to Java 11 and Nextflow 22.04.

The pipeline is currently failing with a cryptic error. However, I am getting this same error on `master` as well, so I think there is a problem with the blast software or input data. I am not sure how to fix it.

```
N E X T F L O W  ~  version 22.04.3
Launching `./main.nf` [exotic_becquerel] DSL1 - revision: b2e2313e83
executor >  local (1)
[49/08492d] process > blast (1) [100%] 1 of 1, failed: 1 ✘
[-        ] process > extract   -
Error executing process > 'blast (1)'

Caused by:
  Process `blast (1)` terminated with an error exit status (139)

Command executed:

  blastp -db pdb/tiny -query query.fa -outfmt 6 > blast_result
  cat blast_result | head -n 10 | cut -f 2 > top_hits

Command exit status:
  139

Command output:
  (empty)

Work dir:
  /home/bent/workspace/nextflow-io_blast-example/work/49/08492d7362d11382c1ce4d4686a591
```